### PR TITLE
While app initialization undefined adalContext issue occurred as scope of 'this' changes as invocation context of function change 

### DIFF
--- a/src/adal8.service.ts
+++ b/src/adal8.service.ts
@@ -240,10 +240,11 @@ export class Adal8Service {
      * @memberOf Adal8Service
      */
     public getUser(): Observable<any> {
+        const _this = this;   // save outer this for inner function
         return bindCallback((cb: (u: adal.User) => User) => {
-            this.adalContext.getUser(function (error: string, user: adal.User) {
+            _this.adalContext.getUser(function (error: string, user: adal.User) {
                 if (error) {
-                    this.adalContext.error('Error when getting user', error);
+                    _this.adalContext.error('Error when getting user', error);
                     cb(null);
                 } else {
                     cb(user);


### PR DESCRIPTION
TypeError: Cannot read property 'adalContext' of undefined
    at vendor.js:100109
    at AuthenticationContext.push../node_modules/adal-angular/lib/adal.js.AuthenticationContext.getUser (vendor.js:98588)
    at vendor.js:100107
    at Observable._subscribe (vendor.js:161575)
    at Observable.push../node_modules/rxjs/internal/Observable.js.Observable._trySubscribe (vendor.js:160701)
    at Observable.push../node_modules/rxjs/internal/Observable.js.Observable.subscribe (vendor.js:160687)
    at AuthService.push../node_modules/@ttx/ttx-core-shared/dist/src/security/auth.service.js.AuthService.initialize (vendor.js:95595)
    at AppComponent.push../src/app/app.component.ts.AppComponent.ngOnInit (main.js:703)
    at checkAndUpdateDirectiveInline (vendor.js:68850)
    at checkAndUpdateNodeInline (vendor.js:77248)